### PR TITLE
Remover 'Consultar Dívida'

### DIFF
--- a/kotlin-project/app/src/main/java/com/eps/creditoffer/activities/MainActivity.kt
+++ b/kotlin-project/app/src/main/java/com/eps/creditoffer/activities/MainActivity.kt
@@ -32,6 +32,11 @@ class MainActivity : AppCompatActivity(), OnItemClickListener {
         println("----MainActivity.onCreate----")
 
         saldo.text = "R$ " + "%.2f".format(currentAccount.balance)
+        if(recentDebt.id==0){
+            debt_component.visibility = View.INVISIBLE
+        }else{
+            debt_component.visibility = View.VISIBLE
+        }
     }
 
     override fun onResume() {
@@ -39,6 +44,14 @@ class MainActivity : AppCompatActivity(), OnItemClickListener {
         println("----MainActivity.onResume----")
         AccountLink.get(currentAccount.id)
         saldo.text = "R$ " + "%.2f".format(currentAccount.balance)
+
+
+        if(recentDebt.id==0){
+            debt_component.visibility = View.INVISIBLE
+        }else{
+            debt_component.visibility = View.VISIBLE
+
+        }
     }
 
     override fun onBackPressed() {

--- a/kotlin-project/app/src/main/res/layout/activity_main.xml
+++ b/kotlin-project/app/src/main/res/layout/activity_main.xml
@@ -150,6 +150,8 @@
         android:layout_marginTop="15dp"
         android:background="#fff"
         android:padding="0dp"
+        android:clickable="true"
+        android:onClick="viewDebts"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/bt2">
@@ -170,9 +172,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:clickable="true"
-            android:onClick="viewDebts"
-            app:srcCompat="@drawable/ic_plus_solid"/>
+            app:srcCompat="@drawable/ic_plus_solid" />
 
         <TextView
             android:id="@+id/textView_debt"


### PR DESCRIPTION
##  Mudanças propostas
<!--- Faça um breve resumo das mudanças feitas. -->
Remover 'Consultar Dívida' , quando não houver dividas.

## _Issue_ relatada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_, mudança ou corrigindo um bug, por favor discuta ou relate em uma _issue_. -->
<!--- Adicione o link para a _issue_ aqui: -->
https://github.com/fga-eps-mds/2019.2-Over26/issues/185

## Tipo de mudanças
<!--- Que tipo de mudança o Pull Request traz para o projeto? -->
O botão consultar divida só sera visível no caso da existência de dividas, e agora o mesmo é completamente clicável(antes era só o simbolo de '+').

